### PR TITLE
develop-payment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,7 @@ Temporary Items
 
 application.properties
 
-# Ignore all env files
+# Ignore all .env files
 .env
 .env.*
 

--- a/src/main/java/com/jobdam/payment/controller/PaymentController.java
+++ b/src/main/java/com/jobdam/payment/controller/PaymentController.java
@@ -1,0 +1,44 @@
+package com.jobdam.payment.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jobdam.payment.dto.PaymentRequestDto;
+import com.jobdam.payment.dto.PaymentResponseDto;
+import com.jobdam.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    // [1] 결제 요청 생성
+    @PostMapping("/create")
+    public ResponseEntity<PaymentResponseDto> createPayment(@RequestBody PaymentRequestDto requestDto) {
+        PaymentResponseDto responseDto = paymentService.createPayment(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // [2] 결제 완료 확인 - 추후 웹훅 or 프론트 콜백에 따라 방식 변경 가능
+    @PostMapping("/confirm")
+    public ResponseEntity<Void> confirmPayment(
+            @RequestParam("imp_uid") String impUid,
+            @RequestParam("merchant_uid") String merchantUid,
+            @RequestBody(required = false) JsonNode iamportResult
+    ) {
+        paymentService.confirmPayment(impUid, merchantUid, iamportResult);
+        return ResponseEntity.ok().build();
+    }
+
+    // [3] 유저의 결제 내역(포인트 사용/충전 포함) 조회
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<PaymentResponseDto>> getUserPayments(@PathVariable Integer userId) {
+        List<PaymentResponseDto> payments = paymentService.getPaymentsByUserId(userId);
+        return ResponseEntity.ok(payments);
+    }
+}

--- a/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
@@ -1,0 +1,15 @@
+package com.jobdam.payment.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentRequestDto {
+
+    private String merchantUid; // 주문번호 (프론트에서 생성 or 백엔드에서 UUID 생성)
+    private Integer amount;     // 결제 금액
+    private String method;      // 결제수단 (예: CARD, KAKAOPAY, POINT 등)
+}

--- a/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
@@ -9,6 +9,10 @@ import lombok.*;
 @Builder
 public class PaymentRequestDto {
 
+    private Integer userId;
+    private Integer point;
+    private Integer paymentTypeCodeId;
+    private int paymentStatusCodeId;
     private String merchantUid; // 주문번호 (프론트에서 생성 or 백엔드에서 UUID 생성)
     private Integer amount;     // 결제 금액
     private String method;      // 결제수단 (예: CARD, KAKAOPAY, POINT 등)

--- a/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
@@ -1,19 +1,14 @@
+// src/main/java/com/jobdam/payment/dto/PaymentRequestDto.java
 package com.jobdam.payment.dto;
 
 import lombok.*;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class PaymentRequestDto {
-
     private Integer userId;
     private Integer point;
     private Integer paymentTypeCodeId;
-    private int paymentStatusCodeId;
-    private String merchantUid; // 주문번호 (프론트에서 생성 or 백엔드에서 UUID 생성)
-    private Integer amount;     // 결제 금액
-    private String method;      // 결제수단 (예: CARD, KAKAOPAY, POINT 등)
+    private String merchantUid;
+    private Integer amount;
+    private String method;
 }

--- a/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
@@ -1,0 +1,21 @@
+package com.jobdam.payment.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentResponseDto {
+
+    private String merchantUid;
+    private String impUid;
+    private Integer amount;
+    private String status;
+    private String method;
+    private LocalDateTime paidAt;
+    private String failReason;
+}

--- a/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
@@ -1,5 +1,6 @@
 package com.jobdam.payment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,8 +15,10 @@ public class PaymentResponseDto {
     private String merchantUid;
     private String impUid;
     private Integer amount;
-    private String status;
+    private int paymentStatusCodeId;
     private String method;
-    private LocalDateTime paidAt;
-    private String failReason;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+//    private String failReason;
+
 }

--- a/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
@@ -1,3 +1,4 @@
+// src/main/java/com/jobdam/payment/dto/PaymentResponseDto.java
 package com.jobdam.payment.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -5,13 +6,8 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
 public class PaymentResponseDto {
-
     private String merchantUid;
     private String impUid;
     private Integer amount;
@@ -19,6 +15,4 @@ public class PaymentResponseDto {
     private String method;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
-//    private String failReason;
-
 }

--- a/src/main/java/com/jobdam/payment/dto/PaymentVerificationDto.java
+++ b/src/main/java/com/jobdam/payment/dto/PaymentVerificationDto.java
@@ -1,0 +1,19 @@
+package com.jobdam.payment.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentVerificationDto {
+
+    private String impUid;       // PortOne 결제 고유 ID
+    private String merchantUid;  // 내가 지정한 주문번호
+
+
+    //결제 교차검증용 DTO
+
+    //이 DTO 이용한 웹훅은 지피티한테 물어보고 필요시 만들어보겠습니다
+}

--- a/src/main/java/com/jobdam/payment/entity/Payment.java
+++ b/src/main/java/com/jobdam/payment/entity/Payment.java
@@ -1,0 +1,61 @@
+package com.jobdam.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payment")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Integer paymentId;
+
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "point", nullable = false)
+    private Integer point; // 충전 or 차감
+
+    @Column(name = "amount")
+    private Integer amount;
+
+    @Column(name = "payment_type_code_id", nullable = false)
+    private Integer paymentTypeCodeId;
+
+    @Column(name = "payment_status_code_id", nullable = false)
+    private Integer paymentStatusCodeId;
+
+    @Column(name = "method", nullable = false, length = 50)
+    private String method;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "imp_uid", unique = true, length = 100)
+    private String impUid;
+
+    @Column(name = "merchant_uid", unique = true, length = 100)
+    private String merchantUid;
+
+    // 결제 상태 (예: READY, PAID, FAILED)
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    // 실제 결제 완료 시간
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    // 실패 사유 (optional)
+    @Column(name = "fail_reason")
+    private String failReason;
+
+}

--- a/src/main/java/com/jobdam/payment/entity/Payment.java
+++ b/src/main/java/com/jobdam/payment/entity/Payment.java
@@ -1,8 +1,8 @@
+// Payment.java
 package com.jobdam.payment.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -23,7 +23,7 @@ public class Payment {
     private Integer userId;
 
     @Column(name = "point", nullable = false)
-    private Integer point; // 충전 or 차감
+    private Integer point;
 
     @Column(name = "amount")
     private Integer amount;
@@ -32,7 +32,8 @@ public class Payment {
     private Integer paymentTypeCodeId;
 
     @Column(name = "payment_status_code_id", nullable = false)
-    private Integer paymentStatusCodeId;
+    @Builder.Default
+    private Integer paymentStatusCodeId = 1;  // 1: SUCCESS
 
     @Column(name = "method", nullable = false, length = 50)
     private String method;
@@ -46,16 +47,13 @@ public class Payment {
     @Column(name = "merchant_uid", unique = true, length = 100)
     private String merchantUid;
 
-    // 결제 상태 (예: READY, PAID, FAILED)
-    @Column(name = "status", nullable = false, length = 20)
-    private String status;
-
-    // 실제 결제 완료 시간
-    @Column(name = "paid_at")
-    private LocalDateTime paidAt;
-
-    // 실패 사유 (optional)
-    @Column(name = "fail_reason")
-    private String failReason;
-
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        if (this.paymentStatusCodeId == null) {
+            this.paymentStatusCodeId = 1;
+        }
+    }
 }

--- a/src/main/java/com/jobdam/payment/entity/Payment.java
+++ b/src/main/java/com/jobdam/payment/entity/Payment.java
@@ -1,21 +1,16 @@
-// Payment.java
+// src/main/java/com/jobdam/payment/entity/Payment.java
 package com.jobdam.payment.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "payment")
-@Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 public class Payment {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "payment_id")
     private Integer paymentId;
 
@@ -25,15 +20,14 @@ public class Payment {
     @Column(name = "point", nullable = false)
     private Integer point;
 
-    @Column(name = "amount")
+    @Column(name = "amount", nullable = false)
     private Integer amount;
 
     @Column(name = "payment_type_code_id", nullable = false)
     private Integer paymentTypeCodeId;
 
     @Column(name = "payment_status_code_id", nullable = false)
-    @Builder.Default
-    private Integer paymentStatusCodeId = 1;  // 1: SUCCESS
+    private Integer paymentStatusCodeId;
 
     @Column(name = "method", nullable = false, length = 50)
     private String method;
@@ -48,12 +42,7 @@ public class Payment {
     private String merchantUid;
 
     @PrePersist
-    protected void onCreate() {
-        if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
-        }
-        if (this.paymentStatusCodeId == null) {
-            this.paymentStatusCodeId = 1;
-        }
+    public void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/jobdam/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/jobdam/payment/repository/PaymentRepository.java
@@ -1,0 +1,20 @@
+package com.jobdam.payment.repository;
+
+import com.jobdam.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+
+    // imp_uid로 중복 결제 방지용 조회
+    Optional<Payment> findByImpUid(String impUid);
+
+    // merchant_uid로 결제 조회
+    Optional<Payment> findByMerchantUid(String merchantUid);
+
+    // 유저의 모든 결제 내역 조회 (포인트 내역 조회에 사용)
+    List<Payment> findByUserId(Integer userId);
+}

--- a/src/main/java/com/jobdam/payment/service/PaymentService.java
+++ b/src/main/java/com/jobdam/payment/service/PaymentService.java
@@ -1,0 +1,82 @@
+package com.jobdam.payment.service;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jobdam.payment.dto.PaymentRequestDto;
+import com.jobdam.payment.dto.PaymentResponseDto;
+import com.jobdam.payment.entity.Payment;
+import com.jobdam.payment.repository.PaymentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public PaymentResponseDto createPayment(PaymentRequestDto requestDto) {
+        //임의로 merchant_uid 생성(또는 프론트에서 받아온 값 사용 가능, 추후 프론트 수정하며 수정 예정)
+        String merchantUid = requestDto.getMerchantUid();
+        if(merchantUid == null||merchantUid.isBlank()) {
+            merchantUid = UUID.randomUUID().toString();
+        }
+
+
+        Payment payment = Payment.builder()
+                .merchantUid(merchantUid)
+                .amount(requestDto.getAmount())
+                .method(requestDto.getMethod())
+                .status("READY") // 초기 상태
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Payment saved = paymentRepository.save(payment);
+
+        return PaymentResponseDto.builder()
+                .merchantUid(saved.getMerchantUid())
+                .amount(saved.getAmount())
+                .method(saved.getMethod())
+                .status(saved.getStatus())
+                .build();
+    }
+
+
+
+    //imp_uid 받아서 실제 결과 저장(webhook 또는 콜백에서 사용)
+    @Transactional
+    public void confirmPayment(String impUid, String merchantUid, JsonNode iamportResult)
+    {
+        Payment payment =  paymentRepository.findByMerchantUid(merchantUid)
+                .orElseThrow(()-> new RuntimeException("결제 내역 없음"));
+
+        payment.setImpUid(impUid);
+        payment.setStatus("PAID");
+        payment.setPaidAt(LocalDateTime.now());
+
+        paymentRepository.save(payment);
+
+    }
+
+    public List<PaymentResponseDto> getPaymentsByUserId(Integer userId) {
+        List<Payment> payments = paymentRepository.findByUserId(userId);
+        return payments.stream()
+                .map(p -> PaymentResponseDto.builder()
+                        .merchantUid(p.getMerchantUid())
+                        .impUid(p.getImpUid())
+                        .amount(p.getAmount())
+                        .method(p.getMethod())
+                        .status(p.getStatus())
+                        .paidAt(p.getPaidAt())
+                        .failReason(p.getFailReason())
+                        .build())
+                .toList();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ server:
   forward-headers-strategy: framework
 
 spring:
+  jackson:
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
   config:
     import: optional:file:.env[.properties]
   datasource:
@@ -12,7 +15,7 @@ spring:
     driver-class-name: ${DB_DRIVER_CLASS_NAME}
   jpa:
     hibernate:
-      ddl-auto: update  # in development (auto table create/modify)
+      ddl-auto: none  # in development (auto table create/modify)
       # ddl-auto: none  # in operation (manual sql management)
     show-sql: true
 


### PR DESCRIPTION
PortOne 규격에 맞게 전면 수정

PortOne API의 결과를 받아와 db에 저장하는 로직 구현

상태 코드 정의
- **1 (SUCCESS)**
    - `POST /api/payments/create` 호출 시 기본으로 설정
    - 결제 요청이 정상 접수된 상태

- **2 (FAILED)**
    - `POST /api/payments/fail?merchant_uid={merchantUid}` 호출 시 설정
    - PG사 오류 등으로 결제 실패 처리된 상태

- **3 (CANCELLED)**
    - `POST /api/payments/cancel?merchant_uid={merchantUid}` 호출 시 설정
    - 사용자 취소 또는 환불 처리된 상태

(기본값 1)

+
Application.yml ddl-auto: none 으로 변경
