### PR TITLE
feat: SNS 피드 상세보기 API 구현

### DIFF
--- a/src/main/java/com/jobdam/sns/controller/SnsPostController.java
+++ b/src/main/java/com/jobdam/sns/controller/SnsPostController.java
@@ -2,6 +2,8 @@ package com.jobdam.sns.controller;
 
 import com.jobdam.sns.dto.SnsPostRequestDto;
 import com.jobdam.sns.dto.SnsPostResponseDto;
+import com.jobdam.sns.dto.SnsPostDetailResponseDto;
+
 import com.jobdam.sns.service.SnsPostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +27,14 @@ public class SnsPostController {
     public SnsPostResponseDto getPost(@PathVariable Integer postId, @RequestParam Integer userId) {
         return snsPostService.getPostById(postId, userId);
     }
+
+    @GetMapping("/{postId}/detail")
+    public SnsPostDetailResponseDto getPostDetail(@PathVariable Integer postId,
+                                                  @RequestParam Integer userId) {
+        return snsPostService.getPostDetail(postId, userId);
+    }
+
+
 
     @PostMapping
     public Integer createPost(@RequestBody SnsPostRequestDto requestDto, @RequestParam Integer userId) {

--- a/src/main/java/com/jobdam/sns/dto/SnsPostDetailResponseDto.java
+++ b/src/main/java/com/jobdam/sns/dto/SnsPostDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.jobdam.sns.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SnsPostDetailResponseDto {
+    private Integer snsPostId;
+    private Integer userId;
+    private String nickname;
+    private String title;
+    private String content;
+    private String imageUrl;
+    private String attachmentUrl;
+    private LocalDateTime createdAt;
+    private int likeCount;
+    private int commentCount;
+    private boolean liked;
+    private boolean bookmarked;
+}

--- a/src/main/java/com/jobdam/sns/entity/Like.java
+++ b/src/main/java/com/jobdam/sns/entity/Like.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter @Setter
 @Entity
-@Table(name = "like")
+@Table(name = "`like`")
 public class Like {
 
     @Id

--- a/src/main/java/com/jobdam/sns/service/SnsPostService.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostService.java
@@ -2,6 +2,7 @@ package com.jobdam.sns.service;
 
 import com.jobdam.sns.dto.SnsPostRequestDto;
 import com.jobdam.sns.dto.SnsPostResponseDto;
+import com.jobdam.sns.dto.SnsPostDetailResponseDto;
 
 import java.util.List;
 
@@ -9,6 +10,7 @@ public interface SnsPostService {
 
     List<SnsPostResponseDto> getAllPosts(Integer currentUserId);
     SnsPostResponseDto getPostById(Integer postId, Integer currentUserId);
+    SnsPostDetailResponseDto getPostDetail(Integer postId, Integer userId);
 
     Integer createPost(SnsPostRequestDto requestDto, Integer userId);
 

--- a/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
@@ -7,9 +7,9 @@ import com.jobdam.sns.repository.BookmarkRepository;
 import com.jobdam.sns.repository.LikeRepository;
 import com.jobdam.sns.repository.SnsCommentRepository;
 import com.jobdam.user.repository.UserRepository;
+import com.jobdam.sns.dto.SnsPostDetailResponseDto;
 
 import com.jobdam.sns.repository.SnsPostRepository;
-import com.jobdam.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -71,6 +71,33 @@ public class SnsPostServiceImpl implements SnsPostService {
         dto.setBookmarked(bookmarkRepository.existsByUserIdAndSnsPostId(currentUserId, postId));
         return dto;
     }
+
+    @Override
+    public SnsPostDetailResponseDto getPostDetail(Integer postId, Integer userId) {
+        SnsPost post = snsPostRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("해당 게시글을 찾을 수 없습니다."));
+
+        int likeCount = likeRepository.countBySnsPostId(postId);
+        int commentCount = snsCommentRepository.countBySnsPostId(postId);
+        boolean liked = likeRepository.existsByUserIdAndSnsPostId(userId, postId);
+        boolean bookmarked = bookmarkRepository.existsByUserIdAndSnsPostId(userId, postId);
+
+        return SnsPostDetailResponseDto.builder()
+                .snsPostId(post.getSnsPostId())
+                .userId(post.getUserId())
+                .nickname(post.getUser().getNickname())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .imageUrl(post.getImageUrl())
+                .attachmentUrl(post.getAttachmentUrl())
+                .createdAt(post.getCreatedAt())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
+                .liked(liked)
+                .bookmarked(bookmarked)
+                .build();
+    }
+
 
     @Override
     @Transactional


### PR DESCRIPTION
- 게시물 상세조회 API (`/api/sns/posts/{postId}/detail`) 추가
- sns post Swagger 테스트 완료
- like entity 변경
