### PR TITLE
feat: SNS 게시글 필터, 검색 기능 구현 

### DIFF
--- a/src/main/java/com/jobdam/sns/controller/SnsPostController.java
+++ b/src/main/java/com/jobdam/sns/controller/SnsPostController.java
@@ -7,6 +7,7 @@ import com.jobdam.sns.dto.SnsPostDetailResponseDto;
 import com.jobdam.sns.service.SnsPostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import com.jobdam.sns.dto.SnsPostFilterDto;
 
 import java.util.List;
 
@@ -16,6 +17,17 @@ import java.util.List;
 public class SnsPostController {
 
     private final SnsPostService snsPostService;
+
+    // 필터 기반 게시글 조회 (작성자 유형 + 정렬 기준)
+
+    @GetMapping("/filter")
+    public List<SnsPostResponseDto> getFilteredPosts(
+            @ModelAttribute SnsPostFilterDto filter,
+            @RequestParam Integer userId
+    ) {
+        return snsPostService.getFilteredPosts(filter, userId);
+    }
+
 
     // 전체 게시글 조회
     @GetMapping

--- a/src/main/java/com/jobdam/sns/controller/SnsPostController.java
+++ b/src/main/java/com/jobdam/sns/controller/SnsPostController.java
@@ -11,12 +11,34 @@ import com.jobdam.sns.dto.SnsPostFilterDto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
 @RestController
 @RequestMapping("/api/sns/posts")
 @RequiredArgsConstructor
 public class SnsPostController {
 
     private final SnsPostService snsPostService;
+
+    @Operation(
+            summary = "SNS 게시글 키워드 검색",
+            description = "제목 또는 본문 내용에 포함된 텍스트로 게시글을 검색합니다."
+    )
+    @GetMapping("/search")
+    public ResponseEntity<List<SnsPostResponseDto>> searchPosts(
+            @Parameter(description = "검색 키워드 (제목 또는 본문 기준)") @RequestParam String keyword,
+            @RequestParam(required = false) Integer userId
+    ) {
+        List<SnsPostResponseDto> results = snsPostService.searchPostsByKeyword(keyword, userId);
+        return ResponseEntity.ok(results);
+    }
+
+
 
     // 필터 기반 게시글 조회 (작성자 유형 + 정렬 기준)
 

--- a/src/main/java/com/jobdam/sns/dto/SnsPostFilterDto.java
+++ b/src/main/java/com/jobdam/sns/dto/SnsPostFilterDto.java
@@ -1,0 +1,19 @@
+package com.jobdam.sns.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SnsPostFilterDto {
+
+    // 작성자 유형 필터: GENERAL, HUNTER, EMPLOYEE
+    private String memberType;
+
+    // 정렬 기준: latest(기본), likes
+    private String sort = "latest";
+}

--- a/src/main/java/com/jobdam/sns/entity/Like.java
+++ b/src/main/java/com/jobdam/sns/entity/Like.java
@@ -25,4 +25,9 @@ public class Like {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sns_post_id", insertable = false, updatable = false)
+    private SnsPost post;
+
 }

--- a/src/main/java/com/jobdam/sns/entity/SnsPost.java
+++ b/src/main/java/com/jobdam/sns/entity/SnsPost.java
@@ -6,6 +6,11 @@ import lombok.Getter;
 import lombok.Setter;
 import java.time.LocalDateTime;
 
+import java.util.ArrayList;
+import java.util.List;
+import com.jobdam.sns.entity.Like;
+
+
 @Getter @Setter
 @Entity
 @Table(name = "sns_post")
@@ -38,6 +43,9 @@ public class SnsPost {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes = new ArrayList<>();
 
     // user 객체
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/jobdam/sns/repository/SnsPostCustomRepository.java
+++ b/src/main/java/com/jobdam/sns/repository/SnsPostCustomRepository.java
@@ -1,0 +1,16 @@
+package com.jobdam.sns.repository;
+
+import com.jobdam.sns.dto.SnsPostFilterDto;
+import com.jobdam.sns.entity.SnsPost;
+
+import java.util.List;
+
+public interface SnsPostCustomRepository {
+
+    /**
+     * 작성자 유형 및 정렬 기준에 따라 SNS 게시글 필터링 조회
+     * @param filter 필터 조건 (작성자 유형, 정렬 기준)
+     * @return 필터링된 SNS 게시글 리스트
+     */
+    List<SnsPost> searchFilteredPosts(SnsPostFilterDto filter);
+}

--- a/src/main/java/com/jobdam/sns/repository/SnsPostCustomRepositoryImpl.java
+++ b/src/main/java/com/jobdam/sns/repository/SnsPostCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.jobdam.sns.repository;
+
+import com.jobdam.sns.dto.SnsPostFilterDto;
+import com.jobdam.sns.entity.SnsPost;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class SnsPostCustomRepositoryImpl implements SnsPostCustomRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<SnsPost> searchFilteredPosts(SnsPostFilterDto filter) {
+        String baseQuery = """
+            SELECT p FROM SnsPost p
+            JOIN FETCH p.user u
+            JOIN FETCH u.memberTypeCode mt
+            LEFT JOIN p.likes l
+        """;
+
+        StringBuilder whereClause = new StringBuilder("WHERE 1=1 ");
+        if (filter.getMemberType() != null && !filter.getMemberType().isBlank()) {
+            whereClause.append("AND mt.code = :memberType ");
+        }
+
+        String orderClause;
+        if ("likes".equalsIgnoreCase(filter.getSort())) {
+            orderClause = "GROUP BY p ORDER BY COUNT(l) DESC";
+        } else {
+            orderClause = "ORDER BY p.createdAt DESC";
+        }
+
+        String finalQuery = baseQuery + whereClause + orderClause;
+
+        TypedQuery<SnsPost> query = em.createQuery(finalQuery, SnsPost.class);
+
+        if (filter.getMemberType() != null && !filter.getMemberType().isBlank()) {
+            query.setParameter("memberType", filter.getMemberType());
+        }
+
+        return query.getResultList();
+    }
+}

--- a/src/main/java/com/jobdam/sns/repository/SnsPostRepository.java
+++ b/src/main/java/com/jobdam/sns/repository/SnsPostRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
     List<SnsPost> findByUserId(Integer userId);
     List<SnsPost> findByTitleContaining(String keyword);
     List<SnsPost> findAllByOrderByCreatedAtDesc();
+    List<SnsPost> findByTitleContainingOrContentContaining(String titleKeyword, String contentKeyword);
 
     @Query("SELECT p FROM SnsPost p JOIN FETCH p.user u JOIN FETCH u.memberTypeCode ORDER BY p.createdAt DESC")
     List<SnsPost> findAllWithUserAndMemberTypeCode();

--- a/src/main/java/com/jobdam/sns/repository/SnsPostRepository.java
+++ b/src/main/java/com/jobdam/sns/repository/SnsPostRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-public interface SnsPostRepository extends JpaRepository<SnsPost, Integer> {
+    public interface SnsPostRepository extends JpaRepository<SnsPost, Integer>, SnsPostCustomRepository {
 
     List<SnsPost> findByUserId(Integer userId);
     List<SnsPost> findByTitleContaining(String keyword);

--- a/src/main/java/com/jobdam/sns/service/SnsPostService.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostService.java
@@ -4,7 +4,6 @@ import com.jobdam.sns.dto.SnsPostFilterDto;
 import com.jobdam.sns.dto.SnsPostRequestDto;
 import com.jobdam.sns.dto.SnsPostResponseDto;
 import com.jobdam.sns.dto.SnsPostDetailResponseDto;
-
 import java.util.List;
 
 public interface SnsPostService {
@@ -20,5 +19,7 @@ public interface SnsPostService {
     List<SnsPostResponseDto> getFilteredPosts(SnsPostFilterDto filter, Integer currentUserId);
 
     List<SnsPostResponseDto> getMyPosts(Integer currentUserId);
+
+    List<SnsPostResponseDto> searchPostsByKeyword(String keyword, Integer userId);
 
 }

--- a/src/main/java/com/jobdam/sns/service/SnsPostService.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostService.java
@@ -1,5 +1,6 @@
 package com.jobdam.sns.service;
 
+import com.jobdam.sns.dto.SnsPostFilterDto;
 import com.jobdam.sns.dto.SnsPostRequestDto;
 import com.jobdam.sns.dto.SnsPostResponseDto;
 import com.jobdam.sns.dto.SnsPostDetailResponseDto;
@@ -16,6 +17,7 @@ public interface SnsPostService {
 
     void updatePost(Integer postId, SnsPostRequestDto requestDto, Integer userId);
     void deletePost(Integer postId, Integer userId);
+    List<SnsPostResponseDto> getFilteredPosts(SnsPostFilterDto filter, Integer currentUserId);
 
     List<SnsPostResponseDto> getMyPosts(Integer currentUserId);
 

--- a/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
@@ -9,6 +9,9 @@ import com.jobdam.sns.repository.SnsCommentRepository;
 import com.jobdam.user.repository.UserRepository;
 import com.jobdam.sns.dto.SnsPostDetailResponseDto;
 import com.jobdam.code.entity.MemberTypeCode;
+import com.jobdam.sns.mapper.SnsPostMapper;
+import com.jobdam.sns.dto.SnsPostFilterDto;
+
 
 import com.jobdam.sns.repository.SnsPostRepository;
 //import jakarta.transaction.Transactional;
@@ -183,4 +186,21 @@ public class SnsPostServiceImpl implements SnsPostService {
 
         snsPostRepository.delete(post);
     }
+    @Override
+    @Transactional(readOnly = true)
+    public List<SnsPostResponseDto> getFilteredPosts(SnsPostFilterDto filter, Integer currentUserId) {
+        List<SnsPost> posts = snsPostRepository.searchFilteredPosts(filter);
+
+        return posts.stream().map(post -> {
+            return SnsPostMapper.toDto(
+                    post,
+                    post.getUser(),
+                    likeRepository.countBySnsPostId(post.getSnsPostId()),
+                    snsCommentRepository.countBySnsPostId(post.getSnsPostId()),
+                    likeRepository.existsByUserIdAndSnsPostId(currentUserId, post.getSnsPostId()),
+                    bookmarkRepository.existsByUserIdAndSnsPostId(currentUserId, post.getSnsPostId())
+            );
+        }).collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
+++ b/src/main/java/com/jobdam/sns/service/SnsPostServiceImpl.java
@@ -203,4 +203,22 @@ public class SnsPostServiceImpl implements SnsPostService {
         }).collect(Collectors.toList());
     }
 
+    @Override
+    public List<SnsPostResponseDto> searchPostsByKeyword(String keyword, Integer userId) {
+        List<SnsPost> posts = snsPostRepository.findByTitleContainingOrContentContaining(keyword, keyword);
+
+        return posts.stream()
+                .map(post -> SnsPostMapper.toDto(
+                        post,
+                        post.getUser(),
+                        likeRepository.countBySnsPostId(post.getSnsPostId()),
+                        snsCommentRepository.countBySnsPostId(post.getSnsPostId()),
+                        likeRepository.existsByUserIdAndSnsPostId(userId, post.getSnsPostId()),
+                        bookmarkRepository.existsByUserIdAndSnsPostId(userId, post.getSnsPostId())
+                ))
+                .collect(Collectors.toList());
+    }
+
+
+
 }

--- a/src/main/java/com/jobdam/user/entity/User.java
+++ b/src/main/java/com/jobdam/user/entity/User.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import java.time.LocalDateTime;
 import com.jobdam.code.entity.MemberTypeCode;
+import com.jobdam.sns.entity.SnsPost;
+
 
 @Getter
 @Setter
@@ -47,6 +49,10 @@ public class User {
     @Column(name = "profile_image_url", length = 255)
     private String profileImageUrl;
 
+   /* @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sns_post_id", insertable = false, updatable = false)
+    private SnsPost post;
+*/
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(


### PR DESCRIPTION
- 좋아요순 / 최신순 정렬 기준 처리
- 작성자 유형별 정렬
- 피그마에 있던 헤드헌터 게시물 보기 안함 (필요 x)
- 검색 기능 (제목, 본문 내용 키워드로 검색됨)
- swagger 테스트 함